### PR TITLE
Fix link to color space from PDGroup

### DIFF
--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/form/PDGroup.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/graphics/form/PDGroup.java
@@ -70,7 +70,7 @@ public final class PDGroup implements COSObjectable
     {
         if (colorSpace == null)
         {
-            colorSpace = PDColorSpace.create(getCOSObject().getDictionaryObject(COSName.COLORSPACE));
+            colorSpace = PDColorSpace.create(getCOSObject().getDictionaryObject(COSName.CS));
         }
         return colorSpace;
     }


### PR DESCRIPTION
According to the specification of PDF Reference 1.4 (1.7), paragraph 7.5.5, Transparency Group may contain Color Space in the 'CS' key, but in the method PDGroup.getColorSpace () the search is implemented with the use of 'ColorSpace' key.
