### PR TITLE
FIX - remove 3rd party Maven repos.

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -119,16 +119,11 @@
     </dependencyManagement>
 
     <repositories>
-        <repository>
-            <id>jbig2.googlecode</id>
-            <name>JBIG2 ImageIO-Plugin repository at googlecode.com</name>
-            <url>http://jbig2-imageio.googlecode.com/svn/maven-repository/</url>
-        </repository>
-        <repository>
-            <id>mygrid-repository</id>
-            <name>myGrid Repository</name>
-            <url>http://www.mygrid.org.uk/maven/repository</url>
-        </repository>
+      <repository>
+        <id>OPF Artefactory</id>
+        <name>OPF Artefactory-releases</name>
+        <url>http://artifactory.opf-labs.org/artifactory/vera-pdfbox-local</url>
+      </repository>
     </repositories>
 
     <profiles>


### PR DESCRIPTION
- removed dependencies on myGrid and Google Maven repos; and
- added OPF artefactory repo.
  This was in response to a failure of the myGrid repo which
  started to serve garbage artefacts. These have been added
  to the OPF repo for now to ensure build reliability.
